### PR TITLE
Fixed infinite loop in fcm_api_v1:reload_access_token function

### DIFF
--- a/src/fcm_api_v1.erl
+++ b/src/fcm_api_v1.erl
@@ -64,7 +64,7 @@ do_push(RegId, Message0, AuthKey, PushUrl) ->
 
 reload_access_token(#{service_file := ServiceFile} = State) ->
     {ok, Bin} = file:read_file(ServiceFile),
-    reload_access_token(State#{service_file_bin => Bin});
+    reload_access_token(maps:remove(service_file, State#{service_file_bin => Bin}));
 reload_access_token(#{service_file_bin := ServiceFileBin} = State) ->
     cancel_timer(State),
     ServiceJson = #{project_id := ProjectId} = jsx:decode(ServiceFileBin, ?JSX_OPTS),


### PR DESCRIPTION
Because instead of create a new State, we add just a new key, the first function (for service_file) still matches and it's called again and again and again etc.